### PR TITLE
Escape test name pattern in jest command

### DIFF
--- a/lua/neotest-jest/init.lua
+++ b/lua/neotest-jest/init.lua
@@ -113,18 +113,20 @@ local function getJestConfig(path)
 end
 
 local function escapeTestPattern(s)
-  return (s:gsub("%(", "%\\(")
+  return (
+    s
+      :gsub("%(", "%\\(")
       :gsub("%)", "%\\)")
       :gsub("%]", "%\\]")
       :gsub("%[", "%\\[")
-      :gsub('%*', '%\\*')
-      :gsub('%+', '%\\+')
-      :gsub('%-', '%\\-')
-      :gsub('%?', '%\\?')
-      :gsub('%$', '%\\$')
-      :gsub('%^', '%\\^')
-      :gsub('%/', '%\\/')
-      )
+      :gsub("%*", "%\\*")
+      :gsub("%+", "%\\+")
+      :gsub("%-", "%\\-")
+      :gsub("%?", "%\\?")
+      :gsub("%$", "%\\$")
+      :gsub("%^", "%\\^")
+      :gsub("%/", "%\\/")
+  )
 end
 
 ---@param args neotest.RunArgs
@@ -177,11 +179,11 @@ end
 
 local function cleanAnsi(s)
   return s
-      :gsub("\x1b%[%d+;%d+;%d+;%d+;%d+m", "")
-      :gsub("\x1b%[%d+;%d+;%d+;%d+m", "")
-      :gsub("\x1b%[%d+;%d+;%d+m", "")
-      :gsub("\x1b%[%d+;%d+m", "")
-      :gsub("\x1b%[%d+m", "")
+    :gsub("\x1b%[%d+;%d+;%d+;%d+;%d+m", "")
+    :gsub("\x1b%[%d+;%d+;%d+;%d+m", "")
+    :gsub("\x1b%[%d+;%d+;%d+m", "")
+    :gsub("\x1b%[%d+;%d+m", "")
+    :gsub("\x1b%[%d+m", "")
 end
 
 local function findErrorPosition(file, errStr)

--- a/lua/neotest-jest/init.lua
+++ b/lua/neotest-jest/init.lua
@@ -112,6 +112,21 @@ local function getJestConfig(path)
   return jestJs
 end
 
+local function escapeTestPattern(s)
+  return (s:gsub("%(", "%\\(")
+      :gsub("%)", "%\\)")
+      :gsub("%]", "%\\]")
+      :gsub("%[", "%\\[")
+      :gsub('%*', '%\\*')
+      :gsub('%+', '%\\+')
+      :gsub('%-', '%\\-')
+      :gsub('%?', '%\\?')
+      :gsub('%$', '%\\$')
+      :gsub('%^', '%\\^')
+      :gsub('%/', '%\\/')
+      )
+end
+
 ---@param args neotest.RunArgs
 ---@return neotest.RunSpec | nil
 function adapter.build_spec(args)
@@ -126,7 +141,7 @@ function adapter.build_spec(args)
   local testNamePattern = "'.*'"
 
   if pos.type == "test" then
-    testNamePattern = "'" .. pos.name:gsub("'", "") .. "$'"
+    testNamePattern = "'" .. escapeTestPattern(pos.name:gsub("'", "")) .. "$'"
   end
 
   local binary = getJestCommand(pos.path) or "jest"
@@ -162,11 +177,11 @@ end
 
 local function cleanAnsi(s)
   return s
-    :gsub("\x1b%[%d+;%d+;%d+;%d+;%d+m", "")
-    :gsub("\x1b%[%d+;%d+;%d+;%d+m", "")
-    :gsub("\x1b%[%d+;%d+;%d+m", "")
-    :gsub("\x1b%[%d+;%d+m", "")
-    :gsub("\x1b%[%d+m", "")
+      :gsub("\x1b%[%d+;%d+;%d+;%d+;%d+m", "")
+      :gsub("\x1b%[%d+;%d+;%d+;%d+m", "")
+      :gsub("\x1b%[%d+;%d+;%d+m", "")
+      :gsub("\x1b%[%d+;%d+m", "")
+      :gsub("\x1b%[%d+m", "")
 end
 
 local function findErrorPosition(file, errStr)


### PR DESCRIPTION
**PR #11** 
Add escaping chars in jest command option --testNamePattern=<regex>. Now we can run single test cointaing special char in test name.

**Before**
![Captures_36](https://user-images.githubusercontent.com/32909388/177003161-c9006036-ce69-4107-bd7b-91c3a4f0e47f.png)
**After**
![Captures_37](https://user-images.githubusercontent.com/32909388/177003162-0875fce9-a98d-4f3b-bd93-d70d545768a3.png)

