### PR TITLE
Run jest command from the adapter root

### DIFF
--- a/lua/neotest-jest/init.lua
+++ b/lua/neotest-jest/init.lua
@@ -173,6 +173,7 @@ function adapter.build_spec(args)
 
   return {
     command = command,
+    cwd = adapter.root(pos.path),
     context = {
       results_path = results_path,
       file = pos.path,

--- a/lua/neotest-jest/init.lua
+++ b/lua/neotest-jest/init.lua
@@ -1,4 +1,5 @@
 ---@diagnostic disable: undefined-field
+local async = require("neotest.async")
 local lib = require("neotest.lib")
 local logger = require("neotest.logging")
 local util = require("lspconfig").util
@@ -132,7 +133,7 @@ end
 ---@param args neotest.RunArgs
 ---@return neotest.RunSpec | nil
 function adapter.build_spec(args)
-  local results_path = vim.fn.tempname() .. ".json"
+  local results_path = async.fn.tempname() .. ".json"
   local tree = args.tree
 
   if not tree then


### PR DESCRIPTION
The main fix is setting the `cwd` to the adapter root. This fixes the case where I'm at the root directory `project/` but I have my frontend code in a subdirectory `project/frontend/`.

I also put a small fix and a cleanup refactor in this PR. Can remove them and put up a separate PR if you prefer.