### PR TITLE
Support defining env arguments for adapters

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ use({
         require('neotest-jest')({
           jestCommand = "npm test --",
           jestConfigFile = "custom.jest.config.ts",
+          env = { CI = true },
         }),
       }
     })

--- a/lua/neotest-jest/init.lua
+++ b/lua/neotest-jest/init.lua
@@ -202,7 +202,7 @@ function adapter.build_spec(args)
       file = pos.path,
     },
     strategy = get_strategy_config(args.strategy, command),
-    env = getEnv(args[2] and args[2].env or {})
+    env = getEnv(args[2] and args[2].env or {}),
   }
 end
 

--- a/lua/neotest-jest/init.lua
+++ b/lua/neotest-jest/init.lua
@@ -155,6 +155,10 @@ local function get_strategy_config(strategy, command)
   end
 end
 
+local function getEnv(specEnv)
+  return specEnv
+end
+
 ---@param args neotest.RunArgs
 ---@return neotest.RunSpec | nil
 function adapter.build_spec(args)
@@ -198,6 +202,7 @@ function adapter.build_spec(args)
       file = pos.path,
     },
     strategy = get_strategy_config(args.strategy, command),
+    env = getEnv(args[2] and args[2].env or {})
   }
 end
 
@@ -317,6 +322,13 @@ setmetatable(adapter, {
     elseif opts.jestConfigFile then
       getJestConfig = function()
         return opts.jestConfigFile
+      end
+    end
+    if is_callable(opts.env) then
+      getEnv = opts.env
+    elseif opts.env then
+      getEnv = function(specEnv)
+        return vim.tbl_extend("force", opts.env, specEnv)
       end
     end
     return adapter

--- a/tests/init_options_spec.lua
+++ b/tests/init_options_spec.lua
@@ -17,13 +17,14 @@ describe("build_spec with override", function()
     local plugin = require("neotest-jest")({
       jestCommand = binary_override,
       jestConfigFile = config_override,
+      env = { override = "override", adapter_override = true },
     })
 
     local positions = plugin.discover_positions("./spec/basic.test.ts"):to_list()
     local tree = Tree.from_list(positions, function(pos)
       return pos.id
     end)
-    local spec = plugin.build_spec({ tree = tree })
+    local spec = plugin.build_spec({ nil, { env = { spec_override = true } }, tree = tree })
 
     assert.is.truthy(spec)
 
@@ -36,5 +37,9 @@ describe("build_spec with override", function()
     assert.contains(command, "./spec/basic.test.ts")
     assert.is.truthy(spec.context.file)
     assert.is.truthy(spec.context.results_path)
+    assert.is.same(
+      spec.env,
+      { override = "override", adapter_override = true, spec_override = true }
+    )
   end)
 end)


### PR DESCRIPTION
Hi 👋 

It would be great if the neotest-jest plugin honoured `env` args passed as adapter config and run spec config, merging the 2 together by default. Hopefully this accomplishes that!

Thanks