### PR TITLE
fix: put cwd behind a config option

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,9 @@ use({
           jestCommand = "npm test --",
           jestConfigFile = "custom.jest.config.ts",
           env = { CI = true },
+          cwd = function(path)
+            return vim.fn.getcwd()
+          end,
         }),
       }
     })


### PR DESCRIPTION
Fixes #29 

Puts the `cwd` spec field behind a configuration option.