### PR TITLE
don't remove quotes from test names

### DIFF
--- a/lua/neotest-jest/init.lua
+++ b/lua/neotest-jest/init.lua
@@ -185,11 +185,11 @@ function adapter.build_spec(args)
   local testNamePattern = "'.*'"
 
   if pos.type == "test" then
-    testNamePattern = "'" .. escapeTestPattern(pos.name:gsub("'", "")) .. "$'"
+    testNamePattern = "'" .. escapeTestPattern(pos.name) .. "$'"
   end
 
   if pos.type == "namespace" then
-    testNamePattern = "'^" .. escapeTestPattern(pos.name:gsub("'", "")) .. "'"
+    testNamePattern = "'^" .. escapeTestPattern(pos.name) .. "'"
   end
 
   local binary = getJestCommand(pos.path)


### PR DESCRIPTION
Removing quotes results in the pattern generated not matching the test if the test name contains quotes.

Fixes #33 