### PR TITLE
feat: filter_dir function

### DIFF
--- a/lua/neotest-jest/init.lua
+++ b/lua/neotest-jest/init.lua
@@ -37,6 +37,10 @@ function adapter.is_test_file(file_path)
   return false
 end
 
+function adapter.filter_dir(name)
+  return name ~= "node_modules"
+end
+
 ---@async
 ---@return neotest.Tree | nil
 function adapter.discover_positions(path)


### PR DESCRIPTION
Neotest core has switched to custom file finding, which requires specifying custom filtering. This prevents node_modules being searched for tests