### PR TITLE
Add support for `--watch` flag

### DIFF
--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -16,9 +16,10 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
-      - uses: JohnnyMorganz/stylua-action@1.0.0
+      - uses: JohnnyMorganz/stylua-action@v2
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+          version: 0.15.1
           # CLI arguments
           args: --color always --check .
   unit_tests:

--- a/README.md
+++ b/README.md
@@ -38,6 +38,28 @@ use({
 
 See neotest's documentation for more information on how to run tests.
 
+### Running tests in watch mode
+
+`jest` allows to run your tests in [watch mode](https://jestjs.io/docs/cli#--watch).
+To run test in this mode you either can enable it globally in the setup:
+
+```lua
+require('neotest').setup({
+  ...,
+  adapters = {
+    require('neotest-jest')({
+      jestCommand = "jest --watch ",
+    }),
+  }
+})
+```
+
+or add a specific keymap to run tests with watch mode:
+
+```lua
+vim.api.nvim_set_keymap("n", "<leader>tw", "<cmd>lua require('neotest').run.run({ jestCommand = 'jest --watch ' })<cr>", {})
+```
+
 ## :gift: Contributing
 
 Please raise a PR if you are interested in adding new functionality or fixing any bugs. When submitting a bug, please include an example spec that can be tested.

--- a/lua/neotest-jest/init.lua
+++ b/lua/neotest-jest/init.lua
@@ -2,7 +2,7 @@
 local async = require("neotest.async")
 local lib = require("neotest.lib")
 local logger = require("neotest.logging")
-local util = require("modified-plugins.neotest-jest.lua.neotest-jest.util")
+local util = require("neotest-jest.util")
 
 ---@class neotest.JestOptions
 ---@field jestCommand? string|fun(): string
@@ -321,7 +321,6 @@ function adapter.build_spec(args)
           return {}
         end
 
-        -- think about nil
         return parsed_json_to_results(parsed, results_path, nil)
       end
     end,

--- a/lua/neotest-jest/init.lua
+++ b/lua/neotest-jest/init.lua
@@ -293,7 +293,6 @@ function adapter.build_spec(args)
     "--testLocationInResults",
     "--verbose",
     "--json",
-    "--watch",
     "--outputFile=" .. results_path,
     "--testNamePattern=" .. testNamePattern,
     pos.path,

--- a/lua/neotest-jest/util.lua
+++ b/lua/neotest-jest/util.lua
@@ -185,7 +185,7 @@ function M.find_package_json_ancestor(startpath)
   end)
 end
 
--- Node: this function is almost entirely taken from https://github.com/nvim-neotest/neotest/blob/master/lua/neotest/lib/file/init.lua#L93-L144
+-- Note: this function is almost entirely taken from https://github.com/nvim-neotest/neotest/blob/master/lua/neotest/lib/file/init.lua#L93-L144
 -- The only difference is that neotest function reads only new lines and this one reads and returns the whole file
 --- Streams data from a file, watching for new data over time
 --- Each time new data arrives function reads whole file and returns its content

--- a/lua/neotest-jest/util.lua
+++ b/lua/neotest-jest/util.lua
@@ -1,3 +1,4 @@
+local async = require("neotest.async")
 local vim = vim
 local validate = vim.validate
 local uv = vim.loop
@@ -182,6 +183,51 @@ function M.find_package_json_ancestor(startpath)
       return path
     end
   end)
+end
+
+-- Node: this function is almost entirely taken from https://github.com/nvim-neotest/neotest/blob/master/lua/neotest/lib/file/init.lua#L93-L144
+-- The only difference is that neotest function reads only new lines and this one reads and returns the whole file
+--- Streams data from a file, watching for new data over time
+--- Each time new data arrives function reads whole file and returns its content
+--- Useful for watching a file which is written to by another process.
+---@async
+---@param file_path string
+---@return (fun(): string, fun()) Iterator and callback to stop streaming
+function M.stream(file_path)
+  local sender, receiver = async.control.channel.mpsc()
+  local read_semaphore = async.control.Semaphore.new(1)
+
+  local open_err, file_fd = async.uv.fs_open(file_path, "r", 438)
+  assert(not open_err, open_err)
+
+  local send_exit, await_exit = async.control.channel.oneshot()
+  local read = function()
+    local permit = read_semaphore:acquire()
+    local stat_err, stat = async.uv.fs_fstat(file_fd)
+    assert(not stat_err, stat_err)
+    local read_err, data = async.uv.fs_read(file_fd, stat.size, 0)
+    assert(not read_err, read_err)
+    permit:forget()
+    sender.send(data)
+  end
+
+  read()
+  local event = vim.loop.new_fs_event()
+  event:start(file_path, {}, function(err, _, _)
+    assert(not err)
+    async.run(read)
+  end)
+
+  local function stop()
+    await_exit()
+    event:stop()
+    local close_err = async.uv.fs_close(file_fd)
+    assert(not close_err, close_err)
+  end
+
+  async.run(stop)
+
+  return receiver.recv, send_exit
 end
 
 return M


### PR DESCRIPTION
Hello!
This PR allows to pass `--watch` flag and streaming test results. 
The solution is heavily inspired by `neotest-python` code ([link](https://github.com/nvim-neotest/neotest-python/blob/master/lua/neotest-python/init.lua#L160))
I think it Closes: https://github.com/haydenmeade/neotest-jest/issues/43
Note: for now when the tests are being rerun the icon on the summary window is not updated due to: https://github.com/nvim-neotest/neotest/issues/169

How to use:
In your setup add flag to `jestCommand` option:
```lua
require("neotest").setup({
  adapters = {
    require("neotest-jest")({
      jestCommand = "jest --watch ",
    }),
  },
}
```

Demo:

https://user-images.githubusercontent.com/35625949/209707959-51967539-3539-4875-ac37-b2e0da85e6f0.mov

TODO:
[x] allow to run tests with `--watch` flag
[x] add documentation how to turn the flag on on
