### PR TITLE
Add instructions for Treesitter parsers

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,12 @@ use({
 })
 ```
 
+Make sure you have the appropriate `treesitter` language parsers installed otherwise no tests will be found:
+
+```
+:TSInstall javascript
+```
+
 ## Usage
 
 See neotest's documentation for more information on how to run tests.


### PR DESCRIPTION
Not sure if this is needed or not but for a little while I thought I had a broken config. Turns out somehow I only had the typescript language parser installed and neotest-jest did not work repeatedly telling be there were no available tests. This might be helpful to explicitly call out for others in future.
